### PR TITLE
fixed syntax of VOLUME command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir /dashing && \
 
 COPY run.sh /
 
-VOLUME ["/dashboards", "/jobs", "/config", "/public", "/widgets"}
+VOLUME ["/dashboards", "/jobs", "/config", "/public", "/widgets"]
 
 EXPOSE 3030
 WORKDIR /dashing


### PR DESCRIPTION
just noticed this, looks like it's currently not working because i'm seeing weird directories on my container that have " and "] in the name.