### PR TITLE
use official ruby base layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM frvi/ruby
+FROM ruby:2.3.1
 
 MAINTAINER Fredrik Vihlborg <fredrik.wihlborg@gmail.com>
-
-RUN gem install bundle dashing
+RUN apt-get update && \
+    apt-get -y install nodejs && \
+    apt-get -y clean
+RUN gem install bundler dashing
 RUN mkdir /dashing && \
     dashing new dashing && \
     cd /dashing && \


### PR DESCRIPTION
Saw the TODO and wanted to contribute the change so it's based on the official Ruby image (debian)